### PR TITLE
allow execution if no ignoredModules or legactyFilesToAppend are specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,9 +53,11 @@ ES6Concatenator.prototype.transform = function (srcDir, destDir) {
     addModule(moduleName)
   }
 
-  var legacyFiles = broccoli.helpers.multiGlob(this.legacyFilesToAppend, {cwd: srcDir})
-  for (i = 0; i < legacyFiles.length; i++) {
-    addLegacyFile(legacyFiles[i])
+  if (this.legacyFilesToAppend && this.legacyFilesToAppend.length) {
+    var legacyFiles = broccoli.helpers.multiGlob(this.legacyFilesToAppend, {cwd: srcDir})
+    for (i = 0; i < legacyFiles.length; i++) {
+      addLegacyFile(legacyFiles[i])
+    }
   }
 
   broccoli.helpers.assertAbsolutePaths([this.outputFile])
@@ -67,7 +69,7 @@ ES6Concatenator.prototype.transform = function (srcDir, destDir) {
 
   function addModule (moduleName) {
     if (modulesAdded[moduleName]) return
-    if (self.ignoredModules.indexOf(moduleName) !== -1) return
+    if (self.ignoredModules && self.ignoredModules.indexOf(moduleName) !== -1) return
     var i
     var modulePath = moduleName + '.js'
     var fullPath = srcDir + '/' + modulePath


### PR DESCRIPTION
If I do not specify legacyFilesToAppend or ignoredModules then I will get unhelpful exceptions:

```
  var componentJs = compileES6(componentAndVendorTree, {
    loaderFile: 'loader.js',
    inputFiles: [
      'dist/**/*.js'
    ],
    wrapInEval: true,
    outputFile: '/dist/ember-metions.js'
  });

```

I need to change the above to this:

```
  var componentJs = compileES6(componentAndVendorTree, {
    loaderFile: 'loader.js',
    legacyFilesToAppend: [],
    ignoredModules: [],
    inputFiles: [
      'dist/**/*.js'
    ],
    wrapInEval: true,
    outputFile: '/dist/ember-metions.js'
  });

```

The PR makes this unnecessary.  It is either this or it changes to a more helpful error message?
