### PR TITLE
Throw the error for downstream handlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,11 @@ ES6Concatenator.prototype.transform = function (srcDir, destDir) {
       var cacheObject = self.cache.es6[statsHash]
       if (cacheObject == null) { // cache miss
         var fileContents = fs.readFileSync(fullPath).toString()
-        var compiler = new ES6Transpiler(fileContents, moduleName)
+        try {
+          var compiler = new ES6Transpiler(fileContents, moduleName)
+        } catch(err) {
+          throw err;
+        }
         // Resolve relative imports by mutating the compiler's list of import nodes
         for (i = 0; i < compiler.imports.length; i++) {
           var importNode = compiler.imports[i]


### PR DESCRIPTION
This one comes from ember-cli issue
[#154](https://github.com/stefanpenner/ember-cli/issues/154).

ember-cli dies with `Unhandled Error` and doesn't recover from exception 
gracefully. Moreover, ember-cli is not aware of the nature of the error.
