### PR TITLE
Allow custom module paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # master
 
+* Added `moduleNameToPath` option.
+* Added `pathToModuleName` option.
+
 # 0.1.4
 
 * Update dependencies

--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ var applicationJs = compileES6(sourceTree, {
 
 * `.wrapInEval` (boolean): Enable or disable wrapping each module in an `eval`
   call with a `//# sourceURL` comment. Defaults to true, though this may change in the future.
+* `.moduleNameToPath` (function): Provide a function that returns the path on disk for a
+  given ES6 module name.
+* `.pathToModuleName` (function): Provide a function to use a custom mapping from path on disk to
+  ES6 module name.

--- a/index.js
+++ b/index.js
@@ -14,6 +14,14 @@ function ES6Concatenator(inputTree, options) {
 
   this.inputTree = inputTree
 
+  this.moduleNameToPath = function(moduleName) {
+    return moduleName + '.js'
+  }
+
+  this.pathToModuleName = function(path) {
+    return path.slice(0, -3)
+  }
+
   for (var key in options) {
     if (options.hasOwnProperty(key)) {
       this[key] = options[key]
@@ -53,7 +61,7 @@ ES6Concatenator.prototype.write = function (readTree, destDir) {
       if (inputFile.slice(-3) !== '.js') {
         throw new Error('ES6 file does not end in .js: ' + inputFile)
       }
-      var moduleName = inputFile.slice(0, -3)
+      var moduleName = self.pathToModuleName(inputFile)
       addModule(moduleName)
     }
 
@@ -74,7 +82,7 @@ ES6Concatenator.prototype.write = function (readTree, destDir) {
       if (modulesAdded[moduleName]) return
       if (self.ignoredModules && self.ignoredModules.indexOf(moduleName) !== -1) return
       var i
-      var modulePath = moduleName + '.js'
+      var modulePath = self.moduleNameToPath(moduleName)
       var fullPath = srcDir + '/' + modulePath
       var imports
       try {


### PR DESCRIPTION
This allows for custom mapping of filenames to ES6 modules.

Specifically, in Ember we exclude `lib` from the generated module names, this provides a simple extension point to perform that kind of customization.
