### PR TITLE
fix path with windows back slash with path.join

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ ES6Concatenator.prototype.write = function (readTree, destDir) {
             }
             // Mutate node
             if (importNode.source.value.slice(0, 1) === '.') {
-              importNode.source.value = path.join(moduleName, '..', importNode.source.value)
+              importNode.source.value = path.join(moduleName, '..', importNode.source.value).replace(/\\/g, '/')
             }
           }
           var compiledModule = compiler.toAMD()


### PR DESCRIPTION
this fixed and issue in `Windows`:
When using `path.join`, path separators get transformed to `\`, they are then interpreted as escaping characters and raise errors.

``` javascript
define('path\to\module');
```

it shoud be either

``` javascript
define('path\\to\\module');
```

or

``` javascript
define('path/to/module');
```

This fix revert back unix separators after join.
