### PR TITLE
Do not require loader to be specified.

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,9 @@ ES6Concatenator.prototype.write = function (readTree, destDir) {
       legacy: {}
     }
 
-    addLegacyFile(self.loaderFile)
+    if (self.loaderFile) {
+      addLegacyFile(self.loaderFile)
+    }
 
     // This glob tends to be the biggest performance hog
     var inputFiles = helpers.multiGlob(self.inputFiles, {cwd: srcDir})


### PR DESCRIPTION
I need to be able to generate multiple ES6 output files, that will be interoperable (think Ember CLI addons), but need to be able to share a single loader.  The solution is quite simple (just have the loader in a shared `vendor.js` that is loaded before the application code), but requires that I provide an empty file to the `loaderFile` option here.
