### PR TITLE
Fix es6-module-transpiler version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "commonjs"
   ],
   "dependencies": {
-    "es6-module-transpiler": "^0.3.6",
+    "es6-module-transpiler": ">=0.3.6 <0.5.0",
     "js-string-escape": "^1.0.0",
     "mkdirp": "^0.3.5",
     "broccoli-writer": "^0.1.1",


### PR DESCRIPTION
`broccoli-es6-concatenator` can use only `es6-module-transpiler` with version < 0.5.0 because in ~0.5.0 `require('es6-module-transpiler').Compiler` has been removed.

See also https://github.com/square/es6-module-transpiler/compare/v0.4.0...v0.5.0#diff-04c6e90faac2675aa89e2176d2eec7d8L87
