### PR TITLE
Added function support for `ignoredModules`. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,6 @@ var applicationJs = compileES6(sourceTree, {
   call with a `//# sourceURL` comment. Defaults to true, though this may change in the future.
 
 * `.loaderFile` (string): When specified prepends the contents of `loaderFile`.
+
+* `.ignoredModules` (array|function): Array: all module names found in the array will be ignored.
+  Function: will be invoked with the moduleName. If true is returned, the module will be ignored.

--- a/index.js
+++ b/index.js
@@ -74,7 +74,9 @@ ES6Concatenator.prototype.write = function (readTree, destDir) {
 
     function addModule (moduleName) {
       if (modulesAdded[moduleName]) return
-      if (self.ignoredModules && self.ignoredModules.indexOf(moduleName) !== -1) return
+      if (typeof self.ignoredModules === 'function') {
+        if(self.ignoredModules(moduleName)) return
+      } else if (self.ignoredModules && self.ignoredModules.indexOf(moduleName) !== -1) return
       var i
       var modulePath = moduleName + '.js'
       var fullPath = srcDir + '/' + modulePath


### PR DESCRIPTION
This behaves like traditional javascript filter functions. It's intended to provide consumers a more advanced strategy for module ignoring.

My use case is that we're transpiling parts of our app into separate .js files, however want to expose full module access across the board. We do this because we have multiple single page apps that share common code (ember component, models, utils, etc). We want to expose the imports from the common code across every single page apps. 

Right now, to achieve this behavior we have to list out every file (or module name) in the `ignoreModules` list. Providing "filter function style" support allows me to be more flexible (IE regex) within my Brocfile.js.

Please let me know if you'd like me to make any formatting changes or if you have other thoughts on this topic. Thanks!!!
