### PR TITLE
source module (for improve error reporting)

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,15 +72,21 @@ ES6Concatenator.prototype.write = function (readTree, destDir) {
 
     self.cache = newCache
 
-    function addModule (moduleName) {
+    function addModule (moduleName, sourceFile) {
       if (modulesAdded[moduleName]) return
       if (self.ignoredModules && self.ignoredModules.indexOf(moduleName) !== -1) return
       var i
       var modulePath = moduleName + '.js'
       var fullPath = srcDir + '/' + modulePath
       var imports
+
       try {
         var statsHash = helpers.hashStats(fs.statSync(fullPath), modulePath)
+      } catch(e) {
+        e.file = sourceFile
+        throw e
+      }
+
         var cacheObject = self.cache.es6[statsHash]
         if (cacheObject == null) { // cache miss
           var fileContents = fs.readFileSync(fullPath).toString()


### PR DESCRIPTION
often when a module fails the first thing you want to know is which module is the dominator.

This PR needs to also follow up with error logging that understands sourceModule + moduleName

cc @lukemelia

related: https://github.com/stefanpenner/ember-cli/pull/2155

![screenshot 2014-09-30 22 50 29](https://cloud.githubusercontent.com/assets/1377/4469690/a74742a2-4916-11e4-86dc-41c0d1cecb5e.png)
